### PR TITLE
Fix comparison of golang versions

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -323,7 +323,7 @@ EOF
   go_version=($(go version))
   local minimum_go_version
   minimum_go_version=go1.9.1
-  if [[ "${go_version[2]}" < "${minimum_go_version}" && "${go_version[2]}" != "devel" ]]; then
+  if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     kube::log::usage_from_stdin <<EOF
 Detected go version: ${go_version[*]}.
 Kubernetes requires ${minimum_go_version} or greater.


### PR DESCRIPTION
Change hack/lib/golang.sh to compare golang
version properly with "sort -s -t. -k 1,1 -k 2,2n -k 3,3n",
which sorts key by key and not as strings.



**What this PR does / why we need it**:
This is a bug fix for one of the kubernetes build scripts. The script hack/lib/golang.sh has a bug in the GO language version detection, which makes builds fail with GO 1.10 and above. This pull request is based on kinvolk master and merely cherry-picks upstream's fix (https://github.com/kubernetes/kubernetes/commit/fc37221db5d08eb9553273ad6202a2557cfde131).

To reproduce the error, run on a system w/ go1.10 or higher (go1.11 in my case):
```
  $ make WHAT=cmd/kubectl
  
  Detected go version: go version go1.11 android/arm64.
  Kubernetes requires go1.9.1 or greater.
  Please install go1.9.1 or later.
 
  !!! [0929 12:30:46] Call tree:                                                                                                                                                              
  !!! [0929 12:30:46]  1: ./hack/run-in-gopath.sh:30 kube::golang::setup_env(...)

```